### PR TITLE
Django 1.9 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ htmlcov/
 .python-version
 .idea
 dist/
+.cache
+.eggs

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
   - TOXENV=py27-django-19
   - TOXENV=py33-django-17
   - TOXENV=py33-django-18
-  - TOXENV=py33-django-19
   - TOXENV=py34-django-17
   - TOXENV=py34-django-18
   - TOXENV=py34-django-19

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,13 @@ script: tox
 env:
   - TOXENV=py27-django-17
   - TOXENV=py27-django-18
+  - TOXENV=py27-django-19
   - TOXENV=py33-django-17
   - TOXENV=py33-django-18
+  - TOXENV=py33-django-19
   - TOXENV=py34-django-17
   - TOXENV=py34-django-18
+  - TOXENV=py34-django-19
 after_success: coveralls
 deploy:
   provider: pypi

--- a/queued_storage/utils.py
+++ b/queued_storage/utils.py
@@ -1,6 +1,7 @@
+from importlib import import_module
+
 import django
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.importlib import import_module
 
 
 def import_attribute(import_path=None, options=None):

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 downloadcache = {distshare}
 args_are_paths = false
 envlist =
-    {py27,py33,py34}-django-{17,18}
+    {py27,py33,py34}-django-{17,18,19}
 
 [testenv]
 basepython =
@@ -17,4 +17,5 @@ whitelist_externals = make
 deps =
     django-17: Django>=1.7,<1.8
     django-18: Django>=1.8,<1.9
+    django-19: Django>=1.9,<2.0
     -rtests/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 downloadcache = {distshare}
 args_are_paths = false
 envlist =
-    {py27,py33,py34}-django-{17,18,19}
+    {py27,py34}-django-19
+    {py27,py33,py34}-django-{17,18}
 
 [testenv]
 basepython =


### PR DESCRIPTION
Fixes the `ImportError: No module named 'django.utils.importlib'` error with Django 1.9.