### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ django-queued-storage
 
 .. image:: https://readthedocs.org/projects/django-queued-storage/badge/?version=latest&style=flat
    :alt: ReadTheDocs
-   :target: http://django-queued-storage.readthedocs.org/en/latest/
+   :target: https://django-queued-storage.readthedocs.io/en/latest/
 
 .. image:: https://img.shields.io/pypi/l/django-queued-storage.svg
    :alt: License BSD

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -225,9 +225,9 @@ man_pages = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'python': ('http://python.readthedocs.org/en/v2.7.2/', None),
-    'django': ('http://django.readthedocs.org/en/latest/', None),
-    'celery': ('http://celery.readthedocs.org/en/latest/', None),
+    'python': ('https://python.readthedocs.io/en/v2.7.2/', None),
+    'django': ('https://django.readthedocs.io/en/latest/', None),
+    'celery': ('https://celery.readthedocs.io/en/latest/', None),
 }
 
 autodoc_member_order = 'bysource'

--- a/queued_storage/backends.py
+++ b/queued_storage/backends.py
@@ -353,7 +353,7 @@ class QueuedS3BotoStorage(QueuedFileSystemStorage):
     """
     A custom :class:`~queued_storage.backends.QueuedFileSystemStorage`
     subclass which uses the ``S3BotoStorage`` storage of the
-    `django-storages <http://django-storages.readthedocs.org/>`_ app as
+    `django-storages <https://django-storages.readthedocs.io/>`_ app as
     the remote storage.
     """
     def __init__(self, remote='storages.backends.s3boto.S3BotoStorage', *args, **kwargs):
@@ -364,7 +364,7 @@ class QueuedCouchDBStorage(QueuedFileSystemStorage):
     """
     A custom :class:`~queued_storage.backends.QueuedFileSystemStorage`
     subclass which uses the ``CouchDBStorage`` storage of the
-    `django-storages <http://django-storages.readthedocs.org/>`_ app as
+    `django-storages <https://django-storages.readthedocs.io/>`_ app as
     the remote storage.
     """
     def __init__(self, remote='storages.backends.couchdb.CouchDBStorage', *args, **kwargs):
@@ -375,7 +375,7 @@ class QueuedDatabaseStorage(QueuedFileSystemStorage):
     """
     A custom :class:`~queued_storage.backends.QueuedFileSystemStorage`
     subclass which uses the ``DatabaseStorage`` storage of the
-    `django-storages <http://django-storages.readthedocs.org/>`_ app as
+    `django-storages <https://django-storages.readthedocs.io/>`_ app as
     the remote storage.
     """
     def __init__(self, remote='storages.backends.database.DatabaseStorage', *args, **kwargs):
@@ -386,7 +386,7 @@ class QueuedFTPStorage(QueuedFileSystemStorage):
     """
     A custom :class:`~queued_storage.backends.QueuedFileSystemStorage`
     subclass which uses the ``FTPStorage`` storage of the
-    `django-storages <http://django-storages.readthedocs.org/>`_ app as
+    `django-storages <https://django-storages.readthedocs.io/>`_ app as
     the remote storage.
     """
     def __init__(self, remote='storages.backends.ftp.FTPStorage', *args, **kwargs):
@@ -397,7 +397,7 @@ class QueuedMogileFSStorage(QueuedFileSystemStorage):
     """
     A custom :class:`~queued_storage.backends.QueuedFileSystemStorage`
     subclass which uses the ``MogileFSStorage`` storage of the
-    `django-storages <http://django-storages.readthedocs.org/>`_ app as
+    `django-storages <https://django-storages.readthedocs.io/>`_ app as
     the remote storage.
     """
     def __init__(self, remote='storages.backends.mogile.MogileFSStorage', *args, **kwargs):
@@ -408,7 +408,7 @@ class QueuedGridFSStorage(QueuedFileSystemStorage):
     """
     A custom :class:`~queued_storage.backends.QueuedFileSystemStorage`
     subclass which uses the ``GridFSStorage`` storage of the
-    `django-storages <http://django-storages.readthedocs.org/>`_ app as
+    `django-storages <https://django-storages.readthedocs.io/>`_ app as
     the remote storage.
     """
     def __init__(self, remote='storages.backends.mongodb.GridFSStorage', *args, **kwargs):
@@ -419,7 +419,7 @@ class QueuedCloudFilesStorage(QueuedFileSystemStorage):
     """
     A custom :class:`~queued_storage.backends.QueuedFileSystemStorage`
     subclass which uses the ``CloudFilesStorage`` storage of the
-    `django-storages <http://django-storages.readthedocs.org/>`_ app as
+    `django-storages <https://django-storages.readthedocs.io/>`_ app as
     the remote storage.
     """
     def __init__(self, remote='storages.backends.mosso.CloudFilesStorage', *args, **kwargs):
@@ -430,7 +430,7 @@ class QueuedSFTPStorage(QueuedFileSystemStorage):
     """
     A custom :class:`~queued_storage.backends.QueuedFileSystemStorage`
     subclass which uses the ``SFTPStorage`` storage of the
-    `django-storages <http://django-storages.readthedocs.org/>`_ app as
+    `django-storages <https://django-storages.readthedocs.io/>`_ app as
     the remote storage.
     """
     def __init__(self, remote='storages.backends.sftpstorage.SFTPStorage', *args, **kwargs):


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.