### PR TITLE
allow newer versions of django-celery

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     ],
     install_requires=[
         'six>=1.10.0',
-        'django-celery>=3.1,<3.2',
+        'django-celery>=3.1',
         'django-appconf >= 0.4',
     ],
     zip_safe=False,


### PR DESCRIPTION
e.g. django-celery 3.2.1