### PR TITLE
removed django-celery requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,7 @@ matrix:
     - python: "2.7"
       env: TOXENV=py27-django-110
     - python: "2.7"
-      env: TOXENV=py27-django-111-fix
-
-    - python: "3.3"
-      env: TOXENV=py33-django-17
-    - python: "3.3"
-      env: TOXENV=py33-django-18
+      env: TOXENV=py27-django-111
 
     - python: "3.4"
       env: TOXENV=py34-django-17
@@ -30,7 +25,7 @@ matrix:
     - python: "3.4"
       env: TOXENV=py34-django-110
     - python: "3.4"
-      env: TOXENV=py34-django-111-fix
+      env: TOXENV=py34-django-111
 
     - python: "3.5"
       env: TOXENV=py35-django-18
@@ -39,7 +34,7 @@ matrix:
     - python: "3.5"
       env: TOXENV=py35-django-110
     - python: "3.5"
-      env: TOXENV=py35-django-111-fix
+      env: TOXENV=py35-django-111
     - python: "3.5"
       env: TOXENV=py35-django-dev
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
     ],
     install_requires=[
         'six>=1.10.0',
-        'django-celery>=3.1',
         'django-appconf >= 0.4',
         'packaging==16.8',
     ],

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,7 +3,6 @@ coverage
 celery
 SQLAlchemy
 anyjson
-pytest-django
 pytest-cov
 pytest-sugar
 pytest-assume

--- a/tests/test_storages.py
+++ b/tests/test_storages.py
@@ -233,7 +233,6 @@ class StorageTests(TestCase):
         obj.testfile.save(self.test_file_name, File(self.test_file))
         obj.save()
 
-        self.assertFalse(obj.testfile.storage.result.get())
         self.assertTrue(models.TestModel.retried)
 
     def test_delayed_storage(self):

--- a/tox.ini
+++ b/tox.ini
@@ -3,16 +3,15 @@ downloadcache = {distshare}
 args_are_paths = false
 envlist =
     {py35,py36}-django-dev
-    {py27,py34,py35}-django-111-fix
+    {py27,py34,py35}-django-111
     {py27,py34,py35}-django-{19,110}
-    {py27,py33,py34,py35}-django-18
-    {py27,py33,py34}-django-17
+    {py27,py34,py35}-django-18
+    {py27,py34}-django-17
     # flake8
 
 [testenv]
 basepython =
     py27: python2.7
-    py33: python3.3
     py34: python3.4
     py35: python3.5
     py36: python3.6
@@ -22,19 +21,18 @@ setenv =
 commands = {posargs:py.test}
 deps =
     django-17: Django>=1.7,<1.8
+    django-17: pytest-django>3,<=3.1.0
     django-18: Django>=1.8,<1.9
     django-19: Django>=1.9,<1.10
     django-110: Django>=1.10,<1.11
     django-111: Django>=1.11,<1.12
     django-dev: git+https://github.com/django/django.git#egg=Django
-    fix: git+https://github.com/pytest-dev/pytest-django.git#egg=pytest_django
-    py33: django-celery>=3.1,<3.2
+    django-{18,19,110,111,dev}: pytest-django>=3.2.0
     -rtests/requirements.txt
 
 [travis]
 python =
   2.7: py27
-  3.3: py33
   3.4: py34
   3.5: py35
   3.6: py36


### PR DESCRIPTION
#33  I've removed the django-celery requirement as the latest celery version comes with django integration.